### PR TITLE
Package name fix for seed projects

### DIFF
--- a/bin/clever-build
+++ b/bin/clever-build
@@ -41,7 +41,7 @@ dir.filter( function ( d ) {
     // we only need to know if it's an official cleverstack repo or not...
     // since the grunt server option is the same, we just literally need to
     // use indexOf
-    if (hasPkgName && ['cleverstack-angular-seed'].indexOf( readPkg.name ) > -1) {
+    if (hasPkgName && ['angular-seed'].indexOf( readPkg.name ) > -1) {
       folders.push( {
         path: path.resolve( path.join( pkg, '..' ) )
       } );

--- a/bin/clever-downgrade
+++ b/bin/clever-downgrade
@@ -32,19 +32,19 @@ var _args = args.map( function ( a ) {
 var findBackend = _args.indexOf( 'backend' );
 if (findBackend > -1) {
   var backendVersion = args[ findBackend ].split( '@' )[ 1 ];
-  args[ findBackend ] = 'cleverstack-node-seed' + ( typeof backendVersion !== "undefined" ? '@' + backendVersion : '' );
+  args[ findBackend ] = 'node-seed' + ( typeof backendVersion !== "undefined" ? '@' + backendVersion : '' );
 }
 
 var findFrontend = _args.indexOf( 'frontend' );
 if (findFrontend > -1) {
   var frontendVersion = args[ findFrontend ].split( '@' )[ 1 ];
-  args[ findFrontend ] = 'cleverstack-node-seed' + ( typeof frontendVersion !== "undefined" ? '@' + frontendVersion : '' );
+  args[ findFrontend ] = 'node-seed' + ( typeof frontendVersion !== "undefined" ? '@' + frontendVersion : '' );
 }
 
 var modules = [ ];
 if (args.length < 1) {
-  modules.push( 'cleverstack-node-seed' );
-  modules.push( 'cleverstack-angular-seed' );
+  modules.push( 'node-seed' );
+  modules.push( 'angular-seed' );
 } else {
   modules = args;
 }

--- a/bin/clever-init
+++ b/bin/clever-init
@@ -114,7 +114,7 @@ function writeLocalJSON ( projectDir ) {
 }
 
 /**
- * Installs the cleverstack-node-seed as 'backend' and then writes
+ * Installs the node-seed as 'backend' and then writes
  * a local JSON file through writeLocalJSON()
  *
  * @return {Promise}
@@ -186,7 +186,7 @@ function setupBackend ( ) {
 }
 
 /**
- * Installs cleverstack-angular-seed as 'frontend'
+ * Installs angular-seed as 'frontend'
  *
  * @return {Promise}
  * @api private
@@ -203,7 +203,7 @@ function setupFrontend( ) {
 
     var pkg = args[ args.indexOf( 'frontend' ) ].split( '@' );
 
-    lib.packages.get( { name: 'cleverstack-angular-seed' + ( typeof pkg[ 1 ] !== "undefined" ? '@' + pkg[ 1 ] : '' ), owner: 'clevertech' }, projectDir )
+    lib.packages.get( { name: 'angular-seed' + ( typeof pkg[ 1 ] !== "undefined" ? '@' + pkg[ 1 ] : '' ), owner: 'clevertech' }, projectDir )
     .then( function ( ) {
       var res = Promise.defer( );
 

--- a/bin/clever-server
+++ b/bin/clever-server
@@ -45,7 +45,7 @@ dir.filter( function ( d ) {
     // we only need to know if it's an official cleverstack repo or not...
     // since the grunt server option is the same, we just literally need to
     // use indexOf
-    if (hasPkgName && ['cleverstack-angular-seed', 'cleverstack-node-seed'].indexOf( readPkg.name ) > -1) {
+    if (hasPkgName && ['angular-seed', 'node-seed'].indexOf( readPkg.name ) > -1) {
       folders.push( {
         name: readPkg.name,
         path: path.resolve( path.join( pkg, '..' ) )
@@ -73,7 +73,7 @@ folders.forEach( function ( folder, i )  {
     args.push( program.port );
   }
 
-  if (folder.name === "cleverstack-node-seed") {
+  if (folder.name === "node-seed") {
     args.push( 'server:web' );
   } else {
     args.push( 'server' );

--- a/bin/clever-upgrade
+++ b/bin/clever-upgrade
@@ -32,19 +32,19 @@ var _args = args.map( function ( a ) {
 var findBackend = _args.indexOf( 'backend' );
 if (findBackend > -1) {
   var backendVersion = args[ findBackend ].split( '@' )[ 1 ];
-  args[ findBackend ] = 'cleverstack-node-seed' + ( typeof backendVersion !== "undefined" ? '@' + backendVersion : '' );
+  args[ findBackend ] = 'node-seed' + ( typeof backendVersion !== "undefined" ? '@' + backendVersion : '' );
 }
 
 var findFrontend = _args.indexOf( 'frontend' );
 if (findFrontend > -1) {
   var frontendVersion = args[ findFrontend ].split( '@' )[ 1 ];
-  args[ findFrontend ] = 'cleverstack-node-seed' + ( typeof frontendVersion !== "undefined" ? '@' + frontendVersion : '' );
+  args[ findFrontend ] = 'node-seed' + ( typeof frontendVersion !== "undefined" ? '@' + frontendVersion : '' );
 }
 
 var modules = [ ];
 if (args.length < 1) {
-  modules.push( 'cleverstack-node-seed' );
-  modules.push( 'cleverstack-angular-seed' );
+  modules.push( 'node-seed' );
+  modules.push( 'angular-seed' );
 } else {
   modules = args;
 }

--- a/tests/init.test.js
+++ b/tests/init.test.js
@@ -20,7 +20,7 @@ function tap ( options, done ) {
         , pkgJson = require( pkgPath );
 
       expect( fs.existsSync( pkgPath ) ).to.be.true;
-      expect( pkgJson.name ).to.equal( 'cleverstack-node-seed' );
+      expect( pkgJson.name ).to.equal( 'node-seed' );
     } else {
       expect( fs.existsSync( path.join( assetPath, options.name, 'backend' ) ) ).to.be.false;
     }
@@ -34,7 +34,7 @@ function tap ( options, done ) {
       expect( fs.existsSync( bowerPath ) ).to.be.true;
 
       var pkgJson2  = require( pkgPath2 );
-      expect( pkgJson2.name ).to.equal( 'cleverstack-angular-seed' );
+      expect( pkgJson2.name ).to.equal( 'angular-seed' );
     } else {
       expect( fs.existsSync( path.join( assetPath, options.name, 'frontend' ) ) ).to.be.false;
     }


### PR DESCRIPTION
The seed projects referenced by the `cleverstack-cli` has names as `cleverstack-angular-seed`, whereas the repos themselves are named as `angular-seed` in their respective `package.json` files. This prevents any operation that requires the package names, such as `clever serve`.

I followed the documentation as it was and got stuck at `clever serve`, till I fixed this.

Also, it's worthwhile looking at how we can abstract out these constants without hardcoding them everywhere.
